### PR TITLE
Add qubo-nn

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ For a curated list of learning resources please check out [desireevl's repo](htt
 - [minorminer](https://github.com/dwavesystems/minorminer) - Heuristic tool for minor graph embedding.
 - [penaltymodel](https://github.com/dwavesystems/penaltymodel) - Utilities and interfaces for using penalty models.
 - [QMASM](https://github.com/lanl/qmasm/) - Quantum macro assembler for D-Wave systems
+- [qubo-nn](https://github.com/instance01/qubo-nn/) - Classifying, auto-encoding and reverse-engineering QUBO matrices. Also includes 20 problem formulations.
 
 **Python, C & Matlab**
 - [Qbsolv](https://github.com/dwavesystems/qbsolv) - QUBO solver with [D-Wave](https://www.dwavesys.com) or classical tabu solver backend.


### PR DESCRIPTION
I've added https://github.com/instance01/qubo-nn/. Contains 20 problem formulations (more to come) and code for reverse-engineering, classifying and auto-encoding QUBOs (e.g. to find the redundancy).