### PR TITLE
Add `mentpy` 

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ For a curated list of learning resources please check out [desireevl's repo](htt
 - [Cirq](https://github.com/quantumlib/Cirq) - Framework for creating, editing, and invoking Noisy Intermediate Scale Quantum (NISQ) circuits.
 - [CUDA Quantum] (https://github.com/NVIDIA/cuda-quantum) C++ and Python support for the CUDA Quantum programming model for heterogeneous quantum-classical workflows.
 - [Forest](https://github.com/rigetticomputing/pyquil) - [Rigetti](https://www.rigetti.com/)'s software library for writing, simulating, compiling and executing quantum programs.
+- [MentPy](https://github.com/BestQuark/mentpy) - Python package for creating and simulating Measurement-based Quantum Computating (MBQC) programs.
 - [Ocean](https://github.com/dwavesystems/dwave-ocean-sdk) - [D-Wave System](https://www.dwavesys.com/home)'s suite of tools for solving hard problems with quantum computers.
 - [OpenQL](https://github.com/QE-Lab/OpenQL) - Compiler framework with algorithm libraries, optimizer, scheduler, QEC, mapping, micro-code generator.
 - [PennyLane](https://pennylane.ai) - Cross-platform Python library for differentiable programming of quantum computers.

--- a/README.md
+++ b/README.md
@@ -49,7 +49,6 @@ For a curated list of learning resources please check out [desireevl's repo](htt
 - [Cirq](https://github.com/quantumlib/Cirq) - Framework for creating, editing, and invoking Noisy Intermediate Scale Quantum (NISQ) circuits.
 - [CUDA Quantum] (https://github.com/NVIDIA/cuda-quantum) C++ and Python support for the CUDA Quantum programming model for heterogeneous quantum-classical workflows.
 - [Forest](https://github.com/rigetticomputing/pyquil) - [Rigetti](https://www.rigetti.com/)'s software library for writing, simulating, compiling and executing quantum programs.
-- [MentPy](https://github.com/BestQuark/mentpy) - Python package for creating and simulating Measurement-based Quantum Computating (MBQC) programs.
 - [Ocean](https://github.com/dwavesystems/dwave-ocean-sdk) - [D-Wave System](https://www.dwavesys.com/home)'s suite of tools for solving hard problems with quantum computers.
 - [OpenQL](https://github.com/QE-Lab/OpenQL) - Compiler framework with algorithm libraries, optimizer, scheduler, QEC, mapping, micro-code generator.
 - [PennyLane](https://pennylane.ai) - Cross-platform Python library for differentiable programming of quantum computers.
@@ -128,6 +127,7 @@ For a curated list of learning resources please check out [desireevl's repo](htt
 
 **Python**
 - [Interlin-q](https://github.com/Interlin-q/Interlin-q) - Quantum network simulator imitating distributed quantum systems with interconnect communication between nodes.
+- [MentPy](https://github.com/BestQuark/mentpy) - Python package for creating and simulating Measurement-based Quantum Computating (MBQC) programs.
 - [MISTIQS](https://github.com/USCCACS/MISTIQS) - Generating/compiling/executing quantum circuits for simulating quantum many-body dynamics of systems.
 - [PIQS](https://github.com/nathanshammah/piqs) - Efficient simulation of open quantum dynamics of identical qubits.
 - [QCircuits](https://github.com/grey-area/qcircuits) - User-friendly quantum circuit simulator designed for students and newcomers to quantum computing.


### PR DESCRIPTION
Hi :), I would like to add `mentpy` to the list ([see here](https://github.com/BestQuark/mentpy)). It is a package for making and simulating measurement-based quantum computing (MBQC) circuits.