### PR TITLE
Added Tangelo and Tangelo examples to the repository list

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ For a curated list of learning resources please check out [desireevl's repo](htt
 - [Qiskit](https://qiskit.org/) - Framework for noisy quantum computers at the level of pulses, circuits, and algorithms (supported by IBM).
 - [quantum-os](https://github.com/quantumos-org/quantum-os)  Operating system based on Linux kernel for quantum computing.
 - [Strawberry Fields](https://github.com/xanaduai/strawberryfields) - [Xanadu](https://www.xanadu.ai)'s software library for photonic quantum computing.
-- [Tangelo](https://github.com/goodchemistryco/Tangelo) Toolkit for quantum chemistry simulation workflows on quantum computers, maintained by SandboxAQ. Tutorials and examples repository at [Tangelo-Examples](https://github.com/goodchemistryco/Tangelo-Examples/).
+- [Tangelo](https://github.com/goodchemistryco/Tangelo) - Toolkit for quantum chemistry simulation workflows on quantum computers, maintained by [SandboxAQ](https://www.sandboxaq.com/). Tutorials and examples repository at [Tangelo-Examples](https://github.com/goodchemistryco/Tangelo-Examples/).
 - [TensorCircuit](https://github.com/tencent-quantum-lab/tensorcircuit) - Tensor network based quantum software framework for the NISQ era.
 - [Tequila](https://github.com/aspuru-guzik-group/tequila) - Extensible Quantum Information and Learning Architecture developed by Alan Aspuru-Guzik's group (UofT).
 

--- a/README.md
+++ b/README.md
@@ -220,6 +220,8 @@ For a curated list of learning resources please check out [desireevl's repo](htt
 - [Quantum TSP](https://github.com/mstechly/quantum_tsp_tutorials) - Tutorials on solving Travelling Salesman Problem using quantum computing (QAOA).
 - [Qudit Team](https://github.com/q-inho/QuditsTeam-1) - Repository to extend Qiskit versatility to higher dimensional quantum states.
 - [spin_qudit_tomography](https://github.com/perlinm/spin_qudit_tomography)  Code used in spin tomography using qudits.
+- [Tangelo](https://github.com/goodchemistryco/Tangelo) Toolkit for quantum chemistry simulation workflows on quantum computers.
+- [Tangelo-Examples](https://github.com/goodchemistryco/Tangelo-Examples/) Tutorials and examples for the modeling of chemical systems with quantum computers, using Tangelo.
 - [Tensorflow Quantum](https://www.tensorflow.org/quantum) - Library for hybrid quantum-classical machine learning.
 - [VQF](https://github.com/mstechly/vqf) - Implementation of Variational Quantum Factoring algorithm (in pyQuil)
 - [WebMark](https://github.com/ohtu2021-kvantti/WebMark) - Web platform for benchmarking quantum computing algorithms.

--- a/README.md
+++ b/README.md
@@ -61,8 +61,7 @@ For a curated list of learning resources please check out [desireevl's repo](htt
 - [Qiskit](https://qiskit.org/) - Framework for noisy quantum computers at the level of pulses, circuits, and algorithms (supported by IBM).
 - [quantum-os](https://github.com/quantumos-org/quantum-os)  Operating system based on Linux kernel for quantum computing.
 - [Strawberry Fields](https://github.com/xanaduai/strawberryfields) - [Xanadu](https://www.xanadu.ai)'s software library for photonic quantum computing.
-- [Tangelo](https://github.com/goodchemistryco/Tangelo) Toolkit for quantum chemistry simulation workflows on quantum computers.
-- [Tangelo-Examples](https://github.com/goodchemistryco/Tangelo-Examples/) Tutorials and examples for the modeling of chemical systems with quantum computers, using Tangelo.
+- [Tangelo](https://github.com/goodchemistryco/Tangelo) Toolkit for quantum chemistry simulation workflows on quantum computers, maintained by SandboxAQ. Tutorials and examples repository at [Tangelo-Examples](https://github.com/goodchemistryco/Tangelo-Examples/).
 - [TensorCircuit](https://github.com/tencent-quantum-lab/tensorcircuit) - Tensor network based quantum software framework for the NISQ era.
 - [Tequila](https://github.com/aspuru-guzik-group/tequila) - Extensible Quantum Information and Learning Architecture developed by Alan Aspuru-Guzik's group (UofT).
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ For a curated list of learning resources please check out [desireevl's repo](htt
 - [Qiskit](https://qiskit.org/) - Framework for noisy quantum computers at the level of pulses, circuits, and algorithms (supported by IBM).
 - [quantum-os](https://github.com/quantumos-org/quantum-os)  Operating system based on Linux kernel for quantum computing.
 - [Strawberry Fields](https://github.com/xanaduai/strawberryfields) - [Xanadu](https://www.xanadu.ai)'s software library for photonic quantum computing.
-- [Tangelo](https://github.com/goodchemistryco/Tangelo) - Toolkit for quantum chemistry simulation workflows on quantum computers, maintained by [SandboxAQ](https://www.sandboxaq.com/). Tutorials and examples repository at [Tangelo-Examples](https://github.com/goodchemistryco/Tangelo-Examples/).
+- [Tangelo](https://github.com/goodchemistryco/Tangelo) and [Tangelo-Examples](https://github.com/goodchemistryco/Tangelo-Examples/) - Toolkit for quantum chemistry simulation workflows on quantum computers, maintained by [SandboxAQ](https://www.sandboxaq.com/).
 - [TensorCircuit](https://github.com/tencent-quantum-lab/tensorcircuit) - Tensor network based quantum software framework for the NISQ era.
 - [Tequila](https://github.com/aspuru-guzik-group/tequila) - Extensible Quantum Information and Learning Architecture developed by Alan Aspuru-Guzik's group (UofT).
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ For a curated list of learning resources please check out [desireevl's repo](htt
 - [Qiskit](https://qiskit.org/) - Framework for noisy quantum computers at the level of pulses, circuits, and algorithms (supported by IBM).
 - [quantum-os](https://github.com/quantumos-org/quantum-os)  Operating system based on Linux kernel for quantum computing.
 - [Strawberry Fields](https://github.com/xanaduai/strawberryfields) - [Xanadu](https://www.xanadu.ai)'s software library for photonic quantum computing.
+- [Tangelo](https://github.com/goodchemistryco/Tangelo) Toolkit for quantum chemistry simulation workflows on quantum computers.
+- [Tangelo-Examples](https://github.com/goodchemistryco/Tangelo-Examples/) Tutorials and examples for the modeling of chemical systems with quantum computers, using Tangelo.
 - [TensorCircuit](https://github.com/tencent-quantum-lab/tensorcircuit) - Tensor network based quantum software framework for the NISQ era.
 - [Tequila](https://github.com/aspuru-guzik-group/tequila) - Extensible Quantum Information and Learning Architecture developed by Alan Aspuru-Guzik's group (UofT).
 
@@ -220,8 +222,6 @@ For a curated list of learning resources please check out [desireevl's repo](htt
 - [Quantum TSP](https://github.com/mstechly/quantum_tsp_tutorials) - Tutorials on solving Travelling Salesman Problem using quantum computing (QAOA).
 - [Qudit Team](https://github.com/q-inho/QuditsTeam-1) - Repository to extend Qiskit versatility to higher dimensional quantum states.
 - [spin_qudit_tomography](https://github.com/perlinm/spin_qudit_tomography)  Code used in spin tomography using qudits.
-- [Tangelo](https://github.com/goodchemistryco/Tangelo) Toolkit for quantum chemistry simulation workflows on quantum computers.
-- [Tangelo-Examples](https://github.com/goodchemistryco/Tangelo-Examples/) Tutorials and examples for the modeling of chemical systems with quantum computers, using Tangelo.
 - [Tensorflow Quantum](https://www.tensorflow.org/quantum) - Library for hybrid quantum-classical machine learning.
 - [VQF](https://github.com/mstechly/vqf) - Implementation of Variational Quantum Factoring algorithm (in pyQuil)
 - [WebMark](https://github.com/ohtu2021-kvantti/WebMark) - Web platform for benchmarking quantum computing algorithms.


### PR DESCRIPTION
Howdy !

Added [Tangelo](https://github.com/goodchemistryco/Tangelo) and [Tangelo-Examples](https://github.com/goodchemistryco/Tangelo-Examples/) to the README under **quantum algorithms**. 

I wonder if Tangelo qualifies for other categories too. Although Tangelo is a collection of building blocks and algorithms for the simulation of quantum chemistry workflows on quantum computers, some of its contents are not necessarily related to chemistry and can be used as simple imports.

- It supports users in designing and carrying hardware experiments (connections to QPUs, manipulation of Histograms, reduction of resources...)
- It offers functions allowing to connect various quantum projects together (Qulacs, Qiskit, Cirq, Q#, Pennylane, ...) and convenient high-level abstractions to several simulators (including an original symbolic simulator in sympy).

Could it qualify as full-stack as well ? Some users have been relying on it for non-chemistry applications.