### PR TITLE
fix: missing "-" character in full-stack libraries section

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ For a curated list of learning resources please check out [desireevl's repo](htt
 ## Quantum full-stack libraries
 
 **C++**
-- [avaloni](https://github.com/avalon-lang/avaloni)  Programming language (interpreter) for classical-quantum hybrid computers.
+- [avaloni](https://github.com/avalon-lang/avaloni) - Programming language (interpreter) for classical-quantum hybrid computers.
 - [CUDA-Q](https://github.com/NVIDIA/cuda-quantum) - Platform for accelerated quantum-classical applications on GPUs, CPUs and QPUs.
 - [staq](https://github.com/softwareqinc/staq) - Full stack quantum processing toolkit ([arXiv paper](https://arxiv.org/abs/1912.06070)).
 - [XACC](https://github.com/ORNL-QCI/xacc) - Extreme-scale programming model for quantum acceleration within high-performance computing ([arXiv paper](https://arxiv.org/abs/1710.01794)).


### PR DESCRIPTION
After trying to regenerate the source list for the website by running [this script ](https://github.com/qosf/qosf.org/blob/master/qosf.org/scripts/github_scraping.py) I noticed that there was an `AttributeError` caused by a formatting issue in this repository.

The line that fails is as follows.

```python
project_description = re.search(r'^.*-.*- (.*)$', line).group(1)
```

As this regex cannot find a "-" in the avaloni entry the search returns `None` hence the attribute error.

```python
project_description = re.search(r'^.*-.*- (.*)$', line).group(1)#.strip('\'')
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'group'
```


After this is merged, I'll be happy to rerun the script and update the source for the site.

See also the PR in progress -> https://github.com/qosf/qosf.org/pull/115