### PR TITLE
add: qxmt on Quantum tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -434,6 +434,7 @@ For a curated list of learning resources please check out [desireevl's repo](htt
 - [qprof](https://gitlab.com/qcomputing/qprof/qprof) - `gprof`-compatible profiler for quantum programs.
 - [QRAND](https://github.com/pedrorrivero/qrand) - Multiplatform and multiprotocol quantum random number generator for arbitrary probability distributions.
 - [QuantumGraphs](https://github.com/ziofil/QuantumGraphs) - Grow and study random graphs by a continuous, randomly collapsing quantum walk.
+- [QXMT](https://github.com/Qyusu/qxmt) - Experiment management tool for quantum computing and quantum machine learning.
 - [toqito](https://github.com/vprusso/toqito) - Framework to study problems pertaining to entanglement theory, nonlocal games, and other aspects of quantum information.
 - [ZXLive](https://github.com/Quantomatic/zxlive) - GUI editor for ZX diagrams.
 


### PR DESCRIPTION
QXMT (Quantum Experiment Management Tool) is an open-source tool designed for managing experiments in quantum machine learning.

Thank you.