### PR TITLE
Add Ombracrypt and Rust category to cryptography section

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,6 +384,9 @@ For a curated list of learning resources please check out [desireevl's repo](htt
 - [Qashchain](https://github.com/TimeMelt/qashchain) - [Quantum blockchain](https://timemelt.itch.io/qashchain) based on [qash-qkdc](https://github.com/TimeMelt/qash-qkdc) circuits.
 - [QRL](https://github.com/theQRL/QRL/) - [Quantum Resistant Ledger](https://theqrl.org/) utilizing hash-based one-time merkle tree signature scheme instead of ECDSA.
 
+**Rust**
+* [Ombracrypt](https://github.com/ABiswasDev/Ombracrypt) - Strictly offline, zero-telemetry file encryption with Post-Quantum Cryptography (PQC) and anti-coercion duress codes.written in rust.
+
 ## Experimental quantum computing
 
 **Julia**

--- a/README.md
+++ b/README.md
@@ -385,7 +385,7 @@ For a curated list of learning resources please check out [desireevl's repo](htt
 - [QRL](https://github.com/theQRL/QRL/) - [Quantum Resistant Ledger](https://theqrl.org/) utilizing hash-based one-time merkle tree signature scheme instead of ECDSA.
 
 **Rust**
-* [Ombracrypt](https://github.com/ABiswasDev/Ombracrypt) - Strictly offline, zero-telemetry file encryption with Post-Quantum Cryptography (PQC) and anti-coercion duress codes.written in rust.
+* [Ombracrypt](https://github.com/ABiswasDev/Ombracrypt) - Strictly offline, zero-telemetry file encryption with Post-Quantum Cryptography (PQC) and anti-coercion duress codes.
 
 ## Experimental quantum computing
 


### PR DESCRIPTION
Adds Ombracrypt to the **Quantum and post-quantum cryptography** section.

- **Tool:** [Ombracrypt](https://github.com/ABiswasDev/Ombracrypt)
- **Description:** A 100% offline, zero-telemetry file encryption utility.

Since Ombracrypt is written in Rust, I added a new `Rust` category beneath the `Python` category to maintain alphabetical ordering per the contribution guidelines. 

Thanks for maintaining this list!